### PR TITLE
Remove streams and avoid unnecessary allocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-CROSS =
-CXX   = $(CROSS)g++
+CXX   = clang++-3.8
 RM    = rm -f
 
 all: demo_sha1 test_sha1

--- a/sha1.hpp
+++ b/sha1.hpp
@@ -15,30 +15,35 @@
         -- Volker Grabsch <vog@notjusthosting.com>
     Safety fixes
         -- Eugene Hopkinson <slowriot at voxelstorm dot com>
+    Remove streams, port to IncludeOS
+        -- fwsGonzo
 */
 
 #ifndef SHA1_HPP
 #define SHA1_HPP
 
-
 #include <cstdint>
-#include <iostream>
 #include <string>
-
 
 class SHA1
 {
 public:
+    static const size_t BLOCK_INTS = 16;  /* number of 32bit integers per SHA1 block */
+    static const size_t BLOCK_BYTES = BLOCK_INTS * 4;
+
     SHA1();
-    void update(const std::string &s);
-    void update(std::istream &is);
+
+    void update(const std::string&);
+    void update(const char*, size_t);
     std::string final();
-    static std::string from_file(const std::string &filename);
+
+    static std::string oneshot(const std::string&);
 
 private:
-    uint32_t digest[5];
-    std::string buffer;
     uint64_t transforms;
+    uint32_t digest[5];
+    uint32_t buffer_len = 0;
+    char     buffer[BLOCK_BYTES+2];
 };
 
 

--- a/test_sha1.cpp
+++ b/test_sha1.cpp
@@ -97,10 +97,24 @@ void test_other()
 /*
  * immitate "sha1sum -b"
  */
-
+#include <fstream>
+#include <streambuf>
 void test_file(const string &filename)
 {
-    cout << SHA1::from_file(filename) << " *" << filename << endl;
+    std::ifstream fstream(filename, std::ios::binary);
+    std::string str;
+
+    fstream.seekg(0, std::ios::end);   
+    str.reserve(fstream.tellg());
+    fstream.seekg(0, std::ios::beg);
+
+    str.assign(std::istreambuf_iterator<char>(fstream),
+               std::istreambuf_iterator<char>());
+
+    SHA1 sha1;
+    sha1.update(str.c_str(), str.size());
+    
+    cout << sha1.final() << " *" << filename << endl;
 }
 
 


### PR DESCRIPTION
I know these changes actually remove (and in some ways detract) from the original implementation. However, I made these changes out of necessity to increase performance and reduce binary bloat due to streams.

In any case, I hope these changes are useful to someone.

Edit: Oops, looks like i changed g++ to clang++-3.8 by mistake!